### PR TITLE
Add downloadURL to distribution

### DIFF
--- a/Schema/example/index.ttl
+++ b/Schema/example/index.ttl
@@ -7,7 +7,7 @@
 @prefix licences: <https://w3id.org/italia/controlled-vocabulary/licences/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
-<https://w3id.org/italia/schema/person/v202108.01/person.oas3.yaml> a dcatapit:Dataset ;
+<https://w3id.org/italia/schema/person/v202108.01/OAS3> a dcatapit:Dataset ;
     dct:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/IRREG> ;
     dct:conformsTo <https://w3id.org/italia/onto/CPV> ;
     dct:description """This Person schema is derived from the [CPV/Person](https://w3id.org/italia/onto/CPV/Person) ontology.
@@ -18,7 +18,7 @@ and other interfaces.""" ;
     dct:rightsHolder <http://spcdata.digitpa.gov.it/Amministrazione/agid> ;
     dct:title "The Person schema" ;
     owl:versionInfo "202108.01.00" ;
-    dcat:distribution <https://raw.githubusercontent.com/ioggstream/json-semantic-playground/master/assets/schemas/person/v202108.01/person.oas3.yaml> ;
+    dcat:distribution <https://w3id.org/italia/schema/person/v202108.01/OAS3.yaml> ;
     admsapt:hasKeyClass cpv:Person ,
                         cpv:PersonTitle ;
     dcat:theme <http://publications.europa.eu/resource/authority/data-theme/EDUC> .
@@ -28,10 +28,11 @@ cpv:Person a owl:Ontology ;
 cpv:PersonTitle a owl:Ontology ;
     <http://www.w3.org/2000/01/rdf-schema#label> "Person Title" .
 
-<https://raw.githubusercontent.com/ioggstream/json-semantic-playground/master/assets/schemas/person/v202108.01/person.oas3.yaml> a dcatapit:Distribution ;
+<https://w3id.org/italia/schema/person/v202108.01/OAS3.yaml> a dcatapit:Distribution ;
     dct:format <http://publications.europa.eu/resource/authority/file-type/JSON> ;
     dct:license licences:A21_CCBY40 ;
     dcat:accessURL <https://github.com/ioggstream/json-semantic-playground/tree/master/assets/schemas/person/v202108.01> ;
+    dcat:downloadURL <https://raw.githubusercontent.com/ioggstream/json-semantic-playground/master/assets/schemas/person/v202108.01/person.oas3.yaml> ;
     dcat:mediaType "application/json" .
 
 <http://spcdata.digitpa.gov.it/Amministrazione/agid> a dcatapit:Agent,


### PR DESCRIPTION
With respect to the original schema definition, the attempt is to make evident that the following are all different concepts:
* the Schema as a whole
* its Distributions (you could have two, with different formats, e.g. YAML and JSON) or support different versions of the OpenAPI specification
* the `accessURL` property of the distribution: my understanding is that this should be human friendly and explaining how to use the downloadable resource. The github folder, in this case, is an excellent example: it presents the content of the folder and the explanation from the `README.md`
* the `downloadURL` is the real URL for downloading the resource, meant to be used also machine-to-machine. This is pivotal for NDC in presenting the Swagger-UI for the attached schema